### PR TITLE
“Use Default Excludes” Checkbox

### DIFF
--- a/src/main/java/com/amazonaws/codedeploy/AWSClients.java
+++ b/src/main/java/com/amazonaws/codedeploy/AWSClients.java
@@ -89,6 +89,8 @@ public class AWSClients {
     /**
      * Via the default provider chain (i.e., global keys for this Jenkins instance),  return the account ID for the
      * currently authenticated user.
+	 * @param proxyHost Proxy host DNS
+	 * @param proxyPort Proxy host port number
      * @return 12-digit account id
      */
     public static String getAccountId(String proxyHost, int proxyPort) {

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
@@ -27,6 +27,11 @@
   <f:entry title="Exclude Files" field="excludes">
     <f:textbox default="" />
   </f:entry>
+  
+  <f:entry title="Use Default (Ant) Excludes List"  field="useDefaultExcludes">
+    <f:checkbox default="true" field="useDefaultExcludes" checked="${instance.getUseDefaultExcludes}" />
+  </f:entry>
+
   <f:entry title="Proxy Host" field="proxyHost">
     <f:textbox default="" />
   </f:entry>

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-useDefaultExcludes.html
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-useDefaultExcludes.html
@@ -1,0 +1,4 @@
+<div>
+    <p>If checked, the deployment will exclude files based on the Ant default exclude list.</p>
+    <p>See <a href='https://ant.apache.org/manual/dirtasks.html#defaultexcludes' target='_blank'>Ant default excludes.</a> </p>
+</div>


### PR DESCRIPTION
The reason for this changes is to address a edge case where we needed to include a ".gitignore" files as part of the deployment.  

The core logic change is to call to the alternate DirScanner.Glob method setting and passing the useDefaultExcludes parameter.  Additionally logic in the DataConstructor was added to set the default behavior to useDefaultExcludes = true for backwards compatibility.   

To the UI, a "Use Default Excludes” checkbox was added allowing operators to control the the behavior.  One anomaly exists with the new checkbox, that is for exist jobs created with previous version, the checkbox will not default to true (checked) even though it is initialized to true by the DataConstructor. 

For the list of files patterns to exclude see https://ant.apache.org/manual/dirtasks.html#defaultexcludes

