### PR TITLE
Add support for environment defined into build of jenkins.

### DIFF
--- a/pom.xml.releaseBackup
+++ b/pom.xml.releaseBackup
@@ -7,7 +7,7 @@
   </parent>
 
   <artifactId>codedeploy</artifactId>
-  <version>1.16-SNAPSHOT</version>
+  <version>1.15-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <groupId>com.amazonaws</groupId>
   <name>AWS CodeDeploy Plugin for Jenkins</name>
@@ -46,8 +46,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jenkins.version>1.612</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>1.580.3</jenkins.version>
   </properties>
 
   <dependencies>
@@ -69,6 +68,13 @@
     <plugins>
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <additionalparam>-Xdoclint:none</additionalparam>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/release.properties
+++ b/release.properties
@@ -1,0 +1,19 @@
+#release configuration
+#Tue Nov 15 18:25:09 UTC 2016
+project.rel.com.amazonaws\:codedeploy=1.15
+scm.tagNameFormat=@{project.artifactId}-@{project.version}
+scm.tag=codedeploy-1.15
+project.scm.com.amazonaws\:codedeploy.tag=HEAD
+pushChanges=true
+scm.url=scm\:git\:ssh\://git@github.com/jenkinsci/aws-codedeploy-plugin.git
+preparationGoals=clean install
+project.scm.com.amazonaws\:codedeploy.url=https\://github.com/jenkinsci/aws-codedeploy-plugin
+project.dev.com.amazonaws\:codedeploy=1.16-SNAPSHOT
+project.scm.com.amazonaws\:codedeploy.connection=scm\:git\:ssh\://github.com/jenkinsci/aws-codedeploy-plugin.git
+remoteTagging=true
+projectVersionPolicyId=default
+scm.commentPrefix=[maven-release-plugin] 
+project.scm.com.amazonaws\:codedeploy.developerConnection=scm\:git\:ssh\://git@github.com/jenkinsci/aws-codedeploy-plugin.git
+exec.snapshotReleasePluginAllowed=false
+exec.additionalArguments=
+completedPhase=end-release

--- a/src/main/java/com/amazonaws/codedeploy/AWSClients.java
+++ b/src/main/java/com/amazonaws/codedeploy/AWSClients.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -74,15 +74,15 @@ public class AWSClients {
         codedeploy.setRegion(Region.getRegion(Regions.fromName(this.region)));
         s3.setRegion(Region.getRegion(Regions.fromName(this.region)));
     }
-    
+
     public static AWSClients fromDefaultCredentialChain(String region, String proxyHost, int proxyPort) {
         return new AWSClients(region, null, proxyHost, proxyPort);
     }
-    
+
     public static AWSClients fromIAMRole(String region, String iamRole, String externalId, String proxyHost, int proxyPort) {
         return new AWSClients(region, getCredentials(iamRole, externalId), proxyHost, proxyPort);
     }
-    
+
     public static AWSClients fromBasicCredentials(String region, String awsAccessKey, String awsSecretKey, String proxyHost, int proxyPort) {
         return new AWSClients(region, new BasicAWSCredentials(awsAccessKey, awsSecretKey), proxyHost, proxyPort);
     }

--- a/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
+++ b/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
@@ -200,12 +200,21 @@ public class AWSCodeDeployPublisher extends Publisher implements SimpleBuildStep
                         this.proxyHost,
                         this.proxyPort);
             } else {
-                aws = AWSClients.fromBasicCredentials(
+                if (StringUtils.isEmpty(envVars.get(this.awsAccessKey)) && StringUtils.isEmpty(envVars.get(this.awsSecretKey))) {
+                    aws = AWSClients.fromBasicCredentials(
                         this.region,
                         this.awsAccessKey,
                         this.awsSecretKey,
                         this.proxyHost,
                         this.proxyPort);
+                } else {
+                    aws = AWSClients.fromBasicCredentials(
+                        this.region,
+                        envVars.get(this.awsAccessKey),
+                        envVars.get(this.awsSecretKey),
+                        this.proxyHost,
+                        this.proxyPort);
+                }
             }
         } else {
             aws = AWSClients.fromIAMRole(

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-awsAccessKey.html
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-awsAccessKey.html
@@ -1,6 +1,8 @@
 <div>
   <p>AWS Access and Secret keys to use for this deployment. At minimum the keys must be allowed to execute
-  <code>codedeploy:*</code> and <code>s3:Put*</code>. It's a best practice to have these keys be from an IAM role
+  <code>codedeploy:*</code> and <code>s3:Put*</code>. 
+  You can also use environment variables defined in jenkins's build for this fields.
+  It's a best practice to have these keys be from an IAM role
   with limited scope.</p>
 
   <p>

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-awsSecretKey.html
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-awsSecretKey.html
@@ -1,6 +1,8 @@
 <div>
   <p>AWS Access and Secret keys to use for this deployment. At minimum the keys must be allowed to execute
-  <code>codedeploy:*</code> and <code>s3:Put*</code>. It's a best practice to have these keys be from an IAM role
+  <code>codedeploy:*</code> and <code>s3:Put*</code>. 
+  You can also use environment variables defined in jenkins's build for this fields.
+  It's a best practice to have these keys be from an IAM role
   with limited scope.</p>
 
   <p>


### PR DESCRIPTION
Hello,

This PR handle the environment variables which are defined in the build process of jenkins. Because with aws-sdk-java, the class **EnvironmentVariableCredentialsProvider** cannot handle it with **System.getEnv**, it's null all the time.