### PR TITLE
Update to use AWSClientBuilder for initializing AWS Clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /pom.xml.releaseBackup
 /release.properties
 /target
+/.factorypath
+/bin/


### PR DESCRIPTION
Update to use AWSClientBuilder when initializing AWS Client. For STS clients, initializing regional client to properly hit STS regional endpoint.